### PR TITLE
Prevent memory issue in SmtpTransport.

### DIFF
--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -98,6 +98,8 @@ class SmtpTransport extends AbstractTransport {
 		$this->_sendData();
 		$this->_disconnect();
 
+		$this->_cakeEmail = null;
+
 		return $this->_content;
 	}
 


### PR DESCRIPTION
Sending emails in a loop using the SmtpTransport can currently lead to memory issues for many/large emails. This PR resolves the issue.
